### PR TITLE
fix(outbox-execute): Fix typo on import of OutgoingMessageState

### DIFF
--- a/packages/outbox-execute/scripts/exec.js
+++ b/packages/outbox-execute/scripts/exec.js
@@ -80,9 +80,12 @@ module.exports = async txnHash => {
   console.log(
     `Waiting for message to be confirmed: Batchnumber: ${batchNumber}, IndexInBatch ${indexInBatch}`
   )
+  console.log(`Outgoing message state: ${OutgoingMessageState[outgoingMessageState]}`)
 
-  while (!outgoingMessageState === OutgoingMessageState.CONFIRMED) {
-    await wait(1000 * 60)
+  const timeToWaitMs = 1000 * 60
+  while (outgoingMessageState !== OutgoingMessageState.CONFIRMED) {
+    console.log(`Message not yet confirmed; we'll wait ${timeToWaitMs / 3600} minutes and try again`)
+    await wait(timeToWaitMs)
     const outgoingMessageState = await bridge.getOutGoingMessageState(
       batchNumber,
       indexInBatch
@@ -100,7 +103,6 @@ module.exports = async txnHash => {
         break
       }
       case OutgoingMessageState.UNCONFIRMED: {
-        console.log(`Message not yet confirmed; we'll wait a bit and try again`)
         break
       }
 

--- a/packages/outbox-execute/scripts/exec.js
+++ b/packages/outbox-execute/scripts/exec.js
@@ -84,7 +84,7 @@ module.exports = async txnHash => {
 
   const timeToWaitMs = 1000 * 60
   while (outgoingMessageState !== OutgoingMessageState.CONFIRMED) {
-    console.log(`Message not yet confirmed; we'll wait ${timeToWaitMs / 3600} minutes and try again`)
+    console.log(`Message not yet confirmed; we'll wait ${timeToWaitMs / 3600} seconds and try again`)
     await wait(timeToWaitMs)
     const outgoingMessageState = await bridge.getOutGoingMessageState(
       batchNumber,

--- a/packages/outbox-execute/scripts/exec.js
+++ b/packages/outbox-execute/scripts/exec.js
@@ -1,5 +1,5 @@
 const { providers, Wallet } = require('ethers')
-const { Bridge, OutGoingMessageState } = require('arb-ts')
+const { Bridge, OutgoingMessageState } = require('arb-ts')
 const { arbLog, requireEnvVariables } = require('arb-shared-dependencies')
 
 require('dotenv').config()
@@ -81,7 +81,7 @@ module.exports = async txnHash => {
     `Waiting for message to be confirmed: Batchnumber: ${batchNumber}, IndexInBatch ${indexInBatch}`
   )
 
-  while (!outgoingMessageState === OutGoingMessageState.CONFIRMED) {
+  while (!outgoingMessageState === OutgoingMessageState.CONFIRMED) {
     await wait(1000 * 60)
     const outgoingMessageState = await bridge.getOutGoingMessageState(
       batchNumber,
@@ -89,17 +89,17 @@ module.exports = async txnHash => {
     )
 
     switch (outgoingMessageState) {
-      case OutGoingMessageState.NOT_FOUND: {
+      case OutgoingMessageState.NOT_FOUND: {
         console.log('Message not found; something strange and bad happened')
         process.exit(1)
         break
       }
-      case OutGoingMessageState.EXECUTED: {
+      case OutgoingMessageState.EXECUTED: {
         console.log(`Message already executed! Nothing else to do here`)
         process.exit(1)
         break
       }
-      case OutGoingMessageState.UNCONFIRMED: {
+      case OutgoingMessageState.UNCONFIRMED: {
         console.log(`Message not yet confirmed; we'll wait a bit and try again`)
         break
       }

--- a/packages/outbox-execute/scripts/exec.js
+++ b/packages/outbox-execute/scripts/exec.js
@@ -84,7 +84,7 @@ module.exports = async txnHash => {
 
   const timeToWaitMs = 1000 * 60
   while (outgoingMessageState !== OutgoingMessageState.CONFIRMED) {
-    console.log(`Message not yet confirmed; we'll wait ${timeToWaitMs / 3600} seconds and try again`)
+    console.log(`Message not yet confirmed; we'll wait ${timeToWaitMs / 1000} seconds and try again`)
     await wait(timeToWaitMs)
     const outgoingMessageState = await bridge.getOutGoingMessageState(
       batchNumber,
@@ -119,5 +119,5 @@ module.exports = async txnHash => {
   const res = await bridge.triggerL2ToL1Transaction(batchNumber, indexInBatch)
   const rec = await res.wait()
 
-  console.log('Done! Your transaction is executed')
+  console.log('Done! Your transaction is executed', rec)
 }


### PR DESCRIPTION
Previous import led to this error:

```
ReferenceError: OutGoingMessageState is not defined
    at module.exports (/Users/nicholaspai/UMA/arbitrum-tutorials/packages/outbox-execute/scripts/exec.js:84:36)
```

I also took the liberty to improve logs to (1) print the current state in human readable form and (2) inform user how long the loop would take to "wait" on the new status. Feel free to ignore the logs.