### PR TITLE
remove extra space in L2RPC envvar

### DIFF
--- a/packages/address-table/.env-sample
+++ b/packages/address-table/.env-sample
@@ -1,5 +1,5 @@
 DEVNET_PRIVKEY="0x your key here"
 
 # this is rinkarby, can use any Arbitrum chain
-L2RPC="https://rinkeby.arbitrum.io/rpc" 
+L2RPC="https://rinkeby.arbitrum.io/rpc"
 

--- a/packages/custom-token-bridging/.env-sample
+++ b/packages/custom-token-bridging/.env-sample
@@ -5,7 +5,7 @@
 DEVNET_PRIVKEY ='0x your key here'
 
 # Hosted Aggregator Node (JSON-RPC Endpoint)
-L2RPC="https://rinkeby.arbitrum.io/rpc" 
+L2RPC="https://rinkeby.arbitrum.io/rpc"
 
 # Ethereum RPC i.e., for rinkeby https://rinkeby.infura.io/v3/<your infura key>
 L1RPC=""

--- a/packages/demo-dapp-election/.env-sample
+++ b/packages/demo-dapp-election/.env-sample
@@ -1,5 +1,5 @@
 DEVNET_PRIVKEY="0x your key here"
 
 # this is rinkarby, can use any Arbitrum chain
-L2RPC="https://rinkeby.arbitrum.io/rpc" 
+L2RPC="https://rinkeby.arbitrum.io/rpc"
 

--- a/packages/demo-dapp-pet-shop/.env-sample
+++ b/packages/demo-dapp-pet-shop/.env-sample
@@ -1,5 +1,5 @@
 DEVNET_PRIVKEY="0x your key here"
 
 # this is rinkarby, can use any Arbitrum chain
-L2RPC="https://rinkeby.arbitrum.io/rpc" 
+L2RPC="https://rinkeby.arbitrum.io/rpc"
 

--- a/packages/eth-deposit/.env-sample
+++ b/packages/eth-deposit/.env-sample
@@ -5,7 +5,7 @@
 DEVNET_PRIVKEY ='0x your key here'
 
 # Hosted Aggregator Node (JSON-RPC Endpoint)
-L2RPC="https://rinkeby.arbitrum.io/rpc" 
+L2RPC="https://rinkeby.arbitrum.io/rpc"
 
 # Ethereum RPC i.e., for rinkeby https://rinkeby.infura.io/v3/<your infura key>
 L1RPC=""

--- a/packages/eth-withdraw/.env-sample
+++ b/packages/eth-withdraw/.env-sample
@@ -5,7 +5,7 @@
 DEVNET_PRIVKEY="0x your key here"
 
 # Hosted Aggregator Node (JSON-RPC Endpoint)
-L2RPC="https://rinkeby.arbitrum.io/rpc" 
+L2RPC="https://rinkeby.arbitrum.io/rpc"
 
 # Ethereum RPC i.e., for rinkeby https://rinkeby.infura.io/v3/<your infura key>
 L1RPC="" 

--- a/packages/greeter/.env-sample
+++ b/packages/greeter/.env-sample
@@ -5,7 +5,7 @@
 DEVNET_PRIVKEY="0x your key here"
 
 # Hosted Aggregator Node (JSON-RPC Endpoint)
-L2RPC="https://rinkeby.arbitrum.io/rpc" 
+L2RPC="https://rinkeby.arbitrum.io/rpc"
 
 # Ethereum RPC i.e., for rinkeby https://rinkeby.infura.io/v3/<your infura key>
 L1RPC=""

--- a/packages/outbox-execute/.env-sample
+++ b/packages/outbox-execute/.env-sample
@@ -5,7 +5,7 @@
 DEVNET_PRIVKEY="0x your key here"
 
 # Hosted Aggregator Node (JSON-RPC Endpoint)
-L2RPC="https://rinkeby.arbitrum.io/rpc" 
+L2RPC="https://rinkeby.arbitrum.io/rpc"
 
 # Ethereum RPC; i.e., for rinkeby https://rinkeby.infura.io/v3/<your infura key>
 L1RPC="" 

--- a/packages/token-deposit/.env-sample
+++ b/packages/token-deposit/.env-sample
@@ -5,7 +5,7 @@
 DEVNET_PRIVKEY="0x your private key"
 
 # Hosted Aggregator Node (JSON-RPC Endpoint)
-L2RPC="https://rinkeby.arbitrum.io/rpc" 
+L2RPC="https://rinkeby.arbitrum.io/rpc"
 
 # Ethereum RPC; i.e., for rinkeby https://rinkeby.infura.io/v3/<your infura key>
 L1RPC=""

--- a/packages/token-withdraw/.env-sample
+++ b/packages/token-withdraw/.env-sample
@@ -5,7 +5,7 @@
 DEVNET_PRIVKEY="0x your key here"
 
 # Hosted Aggregator Node (JSON-RPC Endpoint)
-L2RPC="https://rinkeby.arbitrum.io/rpc" 
+L2RPC="https://rinkeby.arbitrum.io/rpc"
 
 # Ethereum RPC; i.e., for rinkeby https://rinkeby.infura.io/v3/<your infura key>
 L1RPC=""


### PR DESCRIPTION
the extra space after the double quote causes network error because L2RPC envvar would be set to 
`"https://rinkeby.arbitrum.io/rpc"<space>` 