### PR TITLE
added missing param to l2ToL1Msg.execute call

### DIFF
--- a/packages/outbox-execute/scripts/exec.js
+++ b/packages/outbox-execute/scripts/exec.js
@@ -64,7 +64,7 @@ module.exports = async txnHash => {
   /**
    * Execute if not alredy executed
    */
-  if(await l2ToL1Msg.hasExecuted()) {
+  if(await l2ToL1Msg.hasExecuted(proofInfo)) {
     console.log(`Message already executed! Nothing else to do here`)
     process.exit(1)
   }


### PR DESCRIPTION
Currently when trying to run the outbox example, it fails with the following error:
```
An unexpected error occurred:

TypeError: Cannot read properties of undefined (reading 'proof')
    at L2ToL1MessageWriter.hasExecuted (C:\Code\arbitrum-tutorials\packages\outbox-execute\node_modules\@arbitrum\sdk\dist\lib\message\L2ToL1Message.js:120:84) 
    at module.exports (C:\Code\arbitrum-tutorials\packages\outbox-execute\scripts\exec.js:67:22)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at SimpleTaskDefinition.action (C:\Code\arbitrum-tutorials\packages\outbox-execute\hardhat.config.js:19:5)
    at Environment._runTaskDefinition (C:\Code\arbitrum-tutorials\packages\outbox-execute\node_modules\hardhat\src\internal\core\runtime-environment.ts:217:14) 
    at Environment.run (C:\Code\arbitrum-tutorials\packages\outbox-execute\node_modules\hardhat\src\internal\core\runtime-environment.ts:129:14)
    at main (C:\Code\arbitrum-tutorials\packages\outbox-execute\node_modules\hardhat\src\internal\cli\cli.ts:214:5)
```

This is because the call to l2ToL1Msg.hasExecuted needs to pass the proofInfo parameter, as seen in the definition here:
https://github.com/OffchainLabs/arbitrum-sdk/blob/9ac39031459e296c017a103fab97f35800a03cd5/src/lib/message/L2ToL1Message.ts#L248
