### PR TITLE
updating the getL2ToL1Messages params

### DIFF
--- a/packages/outbox-execute/scripts/exec.js
+++ b/packages/outbox-execute/scripts/exec.js
@@ -37,7 +37,7 @@ module.exports = async txnHash => {
    * Note that in principle, a single transaction could trigger any number of outgoing messages; the common case will be there's only one.
    * For the sake of this script, we assume there's only one / just grad the first one.
    */
-  const messages = await l2Receipt.getL2ToL1Messages(l1Wallet, l2Provider)
+  const messages = await l2Receipt.getL2ToL1Messages(l1Wallet)
   const l2ToL1Msg = messages[0]
 
   /**


### PR DESCRIPTION
This PR fixes the error in the script which was thrown as a result of changing the function signature of `l2Receipt.getL2ToL1Messages`