### PR TITLE
Add tutorial "Deposit ETH to a different address"

### DIFF
--- a/packages/eth-deposit-to-different-address/.env-sample
+++ b/packages/eth-deposit-to-different-address/.env-sample
@@ -1,0 +1,11 @@
+# This is a sample .env file for use in local development.
+# Duplicate this file as .env here
+
+# Your Private key
+DEVNET_PRIVKEY="0x your key here"
+
+# Hosted Aggregator Node (JSON-RPC Endpoint). This is Arbitrum Goerli Testnet, can use any Arbitrum chain
+L2RPC="https://goerli-rollup.arbitrum.io/rpc"
+
+# Ethereum RPC; i.e., for Goerli https://goerli.infura.io/v3/<your infura key>
+L1RPC=""

--- a/packages/eth-deposit-to-different-address/.gitignore
+++ b/packages/eth-deposit-to-different-address/.gitignore
@@ -1,0 +1,4 @@
+artifacts/
+cache/
+build/
+node_modules/

--- a/packages/eth-deposit-to-different-address/README.md
+++ b/packages/eth-deposit-to-different-address/README.md
@@ -1,0 +1,36 @@
+# eth-deposit-to-different-address Tutorial
+
+`eth-deposit-to-different-address` shows how to move Ether from Ethereum (Layer 1) into the Arbitrum (Layer 2) chain, to an address different than the depositor.
+
+## How it works (Under the hood)
+
+For the common case of depositing ETH to the same account on L2, use the tutorial [eth-deposit](../eth-deposit/README.md).
+In this specific case, we will use the retryable tickets system to deposit ETH into a different address. We will use the parameter `l2CallValue` of the Retryable ticket to specify the amount of ETH to deposit, and `callValueRefundAddress` to specify the destination address. For more info on Retryable tickets, see [Retryable Tickets documentation](https://developer.offchainlabs.com/docs/l1_l2_messages#depositing-eth-via-retryables).
+
+### **Using Arbitrum SDK tooling**
+
+Our [Arbitrum SDK](https://github.com/OffchainLabs/arbitrum-sdk) provides a simple convenient method for creating a retryable ticket, abstracting away the need for the client to connect to any contracts manually.
+
+See [./exec.js](./scripts/exec.js) for inline explanation.
+
+To run:
+
+```
+yarn run exec
+```
+
+## Config Environment Variables
+
+Set the values shown in `.env-sample` as environmental variables. To copy it into a `.env` file:
+
+```bash
+cp .env-sample .env
+```
+
+(you'll still need to edit some variables, i.e., `DEVNET_PRIVKEY`)
+
+---
+
+Once the script is successfully executed, you can go to the [Arbitrum block explorer](https://goerli-rollup-explorer.arbitrum.io/), enter your address, and see the amount of ETH that has been assigned to the specified address on the Arbitrum chain!
+
+<p align="center"><img src="../../assets/offchain_labs_logo.png" width="600"></p>

--- a/packages/eth-deposit-to-different-address/hardhat.config.js
+++ b/packages/eth-deposit-to-different-address/hardhat.config.js
@@ -1,0 +1,4 @@
+require('@nomiclabs/hardhat-ethers')
+const { hardhatConfig } = require('arb-shared-dependencies')
+
+module.exports = hardhatConfig

--- a/packages/eth-deposit-to-different-address/package.json
+++ b/packages/eth-deposit-to-different-address/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "eth-deposit-to-different-address",
+  "license": "Apache-2.0",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "hardhat compile",
+    "exec": "hardhat run scripts/exec.js"
+  },
+  "devDependencies": {
+    "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "ethers": "^5.4.1",
+    "hardhat": "^2.2.0"
+  },
+  "dependencies": {
+    "@arbitrum/sdk": "^v3.0.0",
+    "dotenv": "^8.2.0"
+  }
+}

--- a/packages/eth-deposit-to-different-address/scripts/exec.js
+++ b/packages/eth-deposit-to-different-address/scripts/exec.js
@@ -1,0 +1,118 @@
+const { utils, providers, Wallet } = require('ethers')
+const { L1ToL2MessageStatus } = require('@arbitrum/sdk')
+const {
+  L1ToL2MessageCreator,
+} = require('@arbitrum/sdk/dist/lib/message/L1ToL2MessageCreator')
+const { ArbSdkError } = require('@arbitrum/sdk/dist/lib/dataEntities/errors')
+const { parseEther } = utils
+const { arbLog, requireEnvVariables } = require('arb-shared-dependencies')
+require('dotenv').config()
+requireEnvVariables(['DEVNET_PRIVKEY', 'L1RPC', 'L2RPC'])
+
+/**
+ * Set up: instantiate L1 / L2 wallets connected to providers
+ */
+const walletPrivateKey = process.env.DEVNET_PRIVKEY
+
+const l1Provider = new providers.JsonRpcProvider(process.env.L1RPC)
+const l2Provider = new providers.JsonRpcProvider(process.env.L2RPC)
+
+const l1Wallet = new Wallet(walletPrivateKey, l1Provider)
+
+/**
+ * Set the destination address and amount to be deposited in L2 (in wei)
+ */
+const destinationAddress = '0x2D98cBc6f944c4bD36EdfE9f98cd7CB57faEC8d6'
+const ethToL2DepositAmount = parseEther('0.0001')
+
+const main = async () => {
+  await arbLog('Deposit Eth via Arbitrum SDK on a different address')
+
+  /**
+   * Use l1Wallet to create an Arbitrum SDK L1ToL2MessageCreator instance
+   * We'll use L1ToL2MessageCreator to easily create a custom Retryable Ticket
+   * to send ETH
+   */
+  const l1ToL2MessageCreator = new L1ToL2MessageCreator(l1Wallet)
+
+  /**
+   * First, let's check the ETH balance of the destination address
+   */
+  const destinationAddressInitialEthBalance = await l2Provider.getBalance(
+    destinationAddress
+  )
+
+  /**
+   * Create Retryable Ticket
+   * This method will call Inbox's createRetryableTicket function which, as the name suggests, will create
+   * a Retryable Ticket with the information we send here. The method will also take care of all gas related
+   * parameters by calling the estimate functions.
+   * The parameters that we'll send to the method to create the transaction are:
+   * - from: L1 address transferring ETH
+   * - to: L2 address receiving ETH
+   * - l2CallValue: The amount of ETH being sent
+   * - callValueRefundAddress: L2 address receiving ETH (same as "to")
+   * - data: Any data we want to send over (we can set it as "0x")
+   */
+  const retryableTicketParams = {
+    from: l1Wallet.address,
+    to: destinationAddress,
+    l2CallValue: ethToL2DepositAmount,
+    callValueRefundAddress: destinationAddress,
+    data: '0x',
+  }
+  const l1SubmissionTx = await l1ToL2MessageCreator.createRetryableTicket(
+    retryableTicketParams,
+    l2Provider
+  )
+  const l1SubmissionTxReceipt = await l1SubmissionTx.wait()
+  console.log(
+    'L1 submission transaction receipt is:',
+    l1SubmissionTxReceipt.transactionHash
+  )
+
+  /**
+   * With the transaction confirmed on L1, we now wait for the L2 side (i.e., balance credited to L2) to be confirmed as well.
+   * Here we're waiting for the Sequencer to include the L2 message in its off-chain queue. The Sequencer should include it in under 10 minutes.
+   * Technically, we create an L1ToL2Message SDK object which has the function waitForStatus that will help us find out when the retryable ticket has been created and redeemed.
+   */
+  console.log('Now we wait for L2 side of the transaction to be executed ⏳')
+  const l1ToL2message = (
+    await l1SubmissionTxReceipt.getL1ToL2Messages(l2Provider)
+  )[0]
+  if (!l1ToL2message) {
+    throw new ArbSdkError('Unexpected missing L1ToL2 message.')
+  }
+  const retryableTicketResult = await l1ToL2message.waitForStatus()
+
+  /**
+   * The `status` property tells us if the l1 to l2 message was successful
+   */
+  retryableTicketResult.status === L1ToL2MessageStatus.REDEEMED
+    ? console.log(
+        `L2 message successful: status: ${
+          L1ToL2MessageStatus[retryableTicketResult.status]
+        }`
+      )
+    : console.log(
+        `L2 message failed: status ${
+          L1ToL2MessageStatus[retryableTicketResult.status]
+        }`
+      )
+
+  /**
+   * Our destination address ETH balance should be updated now
+   */
+  const destinationAddressUpdatedEthBalance = await l2Provider.getBalance(
+    destinationAddress
+  )
+  console.log(
+    `L2 ETH balance of the destination address has been updated from ${destinationAddressInitialEthBalance.toString()} to ${destinationAddressUpdatedEthBalance.toString()}`
+  )
+}
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error)
+    process.exit(1)
+  })


### PR DESCRIPTION
Added new tutorial for depositing ETH to a different address on L2 using Retryable tickets.

This PR needs to be merged before this tutorial is functional: https://github.com/OffchainLabs/arbitrum-sdk/pull/237