### PR TITLE
Change eth-deposit package to TS

### DIFF
--- a/packages/eth-deposit/package.json
+++ b/packages/eth-deposit/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "hardhat compile && tsc",
     "build-esm": "hardhat compile && tsc -p tsconfig-esm.json",
-    "depositETH": "hardhat run scripts/exec.js"
+    "depositETH": "hardhat run scripts/exec.ts"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",

--- a/packages/eth-deposit/package.json
+++ b/packages/eth-deposit/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "hardhat compile && tsc",
+    "build-esm": "hardhat compile && tsc -p tsconfig-esm.json",
     "depositETH": "hardhat run scripts/exec.js"
   },
   "devDependencies": {

--- a/packages/eth-deposit/package.json
+++ b/packages/eth-deposit/package.json
@@ -3,16 +3,20 @@
   "license": "Apache-2.0",
   "version": "1.0.0",
   "scripts": {
-    "build": "hardhat compile",
+    "build": "hardhat compile && tsc",
     "depositETH": "hardhat run scripts/exec.js"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "@types/node": "^18.13.0",
     "ethers": "^5.4.1",
-    "hardhat": "^2.2.0"
+    "hardhat": "^2.2.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.5"
   },
   "dependencies": {
     "@arbitrum/sdk": "^v3.0.0",
+    "arb-shared-dependencies": "^1.0.0",
     "dotenv": "^8.2.0"
   }
 }

--- a/packages/eth-deposit/scripts/exec.ts
+++ b/packages/eth-deposit/scripts/exec.ts
@@ -1,7 +1,8 @@
 import { utils, providers, Wallet } from 'ethers'
 import * as ArbSdk from '@arbitrum/sdk'
 import * as ArbFunc from 'arb-shared-dependencies'
-require('dotenv').config()
+import * as dotenv from 'dotenv'
+dotenv.config()
 ArbFunc.requireEnvVariables(['DEVNET_PRIVKEY', 'L1RPC', 'L2RPC'])
 const { parseEther } = utils
 const { EthBridger, EthDepositStatus } = ArbSdk

--- a/packages/eth-deposit/scripts/exec.ts
+++ b/packages/eth-deposit/scripts/exec.ts
@@ -1,18 +1,14 @@
-const { utils, providers, Wallet } = require('ethers')
-const {
-  EthBridger,
-  getL2Network,
-  EthDepositStatus,
-} = require('@arbitrum/sdk')
-const { parseEther } = utils
-const { arbLog, requireEnvVariables } = require('arb-shared-dependencies')
+import { utils, providers, Wallet } from 'ethers'
+import { EthBridger, getL2Network, EthDepositStatus } from '@arbitrum/sdk'
+import { arbLog, requireEnvVariables } from 'arb-shared-dependencies'
 require('dotenv').config()
 requireEnvVariables(['DEVNET_PRIVKEY', 'L1RPC', 'L2RPC'])
+const { parseEther } = utils
 
 /**
  * Set up: instantiate L1 / L2 wallets connected to providers
  */
-const walletPrivateKey = process.env.DEVNET_PRIVKEY
+const walletPrivateKey = process.env.DEVNET_PRIVKEY as string
 
 const l1Provider = new providers.JsonRpcProvider(process.env.L1RPC)
 const l2Provider = new providers.JsonRpcProvider(process.env.L2RPC)
@@ -47,12 +43,10 @@ const main = async () => {
    * Arguments required are:
    * (1) amount: The amount of ETH to be transferred to L2
    * (2) l1Signer: The L1 address transferring ETH to L2
-   * (3) l2Provider: An l2 provider
    */
   const depositTx = await ethBridger.deposit({
     amount: ethToL2DepositAmount,
-    l1Signer: l1Wallet,
-    l2Provider: l2Provider,
+    l1Signer: l1Wallet
   })
 
   const depositRec = await depositTx.wait()

--- a/packages/eth-deposit/scripts/exec.ts
+++ b/packages/eth-deposit/scripts/exec.ts
@@ -1,9 +1,10 @@
 import { utils, providers, Wallet } from 'ethers'
-import { EthBridger, getL2Network, EthDepositStatus } from '@arbitrum/sdk'
-import { arbLog, requireEnvVariables } from 'arb-shared-dependencies'
+import * as ArbSdk from '@arbitrum/sdk'
+import * as ArbFunc from 'arb-shared-dependencies'
 require('dotenv').config()
-requireEnvVariables(['DEVNET_PRIVKEY', 'L1RPC', 'L2RPC'])
+ArbFunc.requireEnvVariables(['DEVNET_PRIVKEY', 'L1RPC', 'L2RPC'])
 const { parseEther } = utils
+const { EthBridger, EthDepositStatus } = ArbSdk
 
 /**
  * Set up: instantiate L1 / L2 wallets connected to providers
@@ -22,14 +23,14 @@ const l2Wallet = new Wallet(walletPrivateKey, l2Provider)
 const ethToL2DepositAmount = parseEther('0.0001')
 
 const main = async () => {
-  await arbLog('Deposit Eth via Arbitrum SDK')
+  await ArbFunc.arbLog('Deposit Eth via Arbitrum SDK')
 
   /**
    * Use l2Network to create an Arbitrum SDK EthBridger instance
    * We'll use EthBridger for its convenience methods around transferring ETH to L2
    */
 
-  const l2Network = await getL2Network(l2Provider)
+  const l2Network = await ArbSdk.getL2Network(l2Provider)
   const ethBridger = new EthBridger(l2Network)
 
   /**

--- a/packages/eth-deposit/scripts/types.d.ts
+++ b/packages/eth-deposit/scripts/types.d.ts
@@ -1,1 +1,2 @@
-declare module 'arb-shared-dependencies';
+declare module 'arb-shared-dependencies'
+declare module 'dotenv'

--- a/packages/eth-deposit/scripts/types.d.ts
+++ b/packages/eth-deposit/scripts/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'arb-shared-dependencies';

--- a/packages/eth-deposit/tsconfig-esm.json
+++ b/packages/eth-deposit/tsconfig-esm.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ES2020",
+        "moduleResolution": "node16"
+    }
+}

--- a/packages/eth-deposit/tsconfig.json
+++ b/packages/eth-deposit/tsconfig.json
@@ -13,7 +13,7 @@
     "strictNullChecks": true,
     "noImplicitThis": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "experimentalDecorators": true
   },
   "include": ["scripts/**/*.ts", "scripts/**/*.d.ts", "scripts/**/*.js"],

--- a/packages/eth-deposit/tsconfig.json
+++ b/packages/eth-deposit/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs",
+    "declaration": true,
+    "rootDir": "./scripts",
+    "outDir": "./build",
+    "strict": true,
+    "allowJs": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true
+  },
+  "include": ["scripts/**/*.ts", "scripts/**/*.d.ts", "scripts/**/*.js"],
+  "ts-node": {
+    "files": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1143,6 +1143,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
+"@types/node@^18.13.0":
+  version "18.13.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.13.0.tgz#0400d1e6ce87e9d3032c19eb6c58205b0d3f7850"
+  integrity sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==
+
 "@types/pbkdf2@^3.0.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@types/pbkdf2/-/pbkdf2-3.1.0.tgz#039a0e9b67da0cdc4ee5dab865caa6b267bb66b1"
@@ -8213,7 +8218,7 @@ ts-generator@^0.1.1:
     resolve "^1.8.1"
     ts-essentials "^1.0.0"
 
-ts-node@^10.8.1:
+ts-node@^10.8.1, ts-node@^10.9.1:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -8338,6 +8343,11 @@ typescript@^4.7.3:
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
+
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
First attempt to move one tutorial to TS (eth deposit).
I only changed the `require` instructions to `imports`, and had to cast the first config variable to string.

It looks like the result when compiling is quite good. You can compile the file with `yarn build` , or see this gist => https://gist.github.com/TucksonDev/22efa85dc7fd0f0546b3a590bb9e496d

I added the needed packages to this tutorial's package.json, but ideally we would have them at the root level if we change all tutorials to TS.