### PR TITLE
Removed enforced gas limit when using the default network for hardhat

### DIFF
--- a/packages/arb-shared-dependencies/hardhat.config.js
+++ b/packages/arb-shared-dependencies/hardhat.config.js
@@ -22,6 +22,13 @@ module.exports = {
     ],
   },
   networks: {
+    // When running the tutorials, we generally don't specify a network to use, but we configure the desired network
+    // in the .env file. Thus, we generally end up using the default network config within hardhat, the "hardhat" network.
+    // However, hardhat network config has some defaults that we want to override because they don't make sense
+    // in other networks.
+    hardhat: {
+      gas: 'auto', // Default is 30000000
+    },
     l1: {
       gas: 2100000,
       gasLimit: 0,


### PR DESCRIPTION
When running the tutorials, we generally don't specify a network to use, but we configure the desired network in the .env file. Thus, we generally end up using the default network config within hardhat, the "hardhat" network.
However, hardhat network config has some defaults that we want to override because they don't make sense in other networks. For example, the base gas limit ("gas" parameter).