### PR TITLE
Add possibility to use a global .env file in the root of the project

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,11 @@
+# This is a sample .env file for use in local development.
+# Duplicate this file as .env here
+
+# Your Private key
+DEVNET_PRIVKEY="0x your key here"
+
+# Hosted Aggregator Node (JSON-RPC Endpoint). This is Arbitrum Goerli Testnet, can use any Arbitrum chain
+L2RPC="https://goerli-rollup.arbitrum.io/rpc"
+
+# Ethereum RPC; i.e., for Goerli https://goerli.infura.io/v3/<your infura key>
+L1RPC=""

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.env
 node_modules/
 packages/.DS_Store
 packages/*/.DS_Store

--- a/packages/arb-shared-dependencies/index.js
+++ b/packages/arb-shared-dependencies/index.js
@@ -1,5 +1,6 @@
 const hardhatConfig = require('./hardhat.config.js')
-require('dotenv').config()
+const path = require('path')
+require('dotenv').config({ path: path.join(__dirname, '..', '..', '.env') })
 
 const wait = (ms = 0) => {
   return new Promise(res => setTimeout(res, ms || 0))

--- a/packages/gas-estimation/scripts/exec.ts
+++ b/packages/gas-estimation/scripts/exec.ts
@@ -2,9 +2,11 @@ import { utils, providers } from "ethers";
 import { ArbGasInfo__factory } from "@arbitrum/sdk/dist/lib/abi/factories/ArbGasInfo__factory";
 import { NodeInterface__factory } from "@arbitrum/sdk/dist/lib/abi/factories/NodeInterface__factory";
 import { ARB_GAS_INFO, NODE_INTERFACE_ADDRESS } from "@arbitrum/sdk/dist/lib/dataEntities/constants";
+const { requireEnvVariables } = require('arb-shared-dependencies');
 
 // Importing configuration //
 require('dotenv').config();
+requireEnvVariables(['L2RPC']);
 
 // Initial setup //
 const baseL2Provider = new providers.StaticJsonRpcProvider(process.env.L2RPC);


### PR DESCRIPTION
This change allows us to have a .env file in the root of the project with all common environment variables.
However, it also allows for local .env files in each package (it will override the variable from the root .env file if present.

For reference, there are usually 5 calls to dotenv.config() within the execution of a script:
1. From the package's hardhat.config.js => arb-shared-dependencies/index.js => arb-shared-dependencies/hardhat.config.js => dotenv.config()
2. From the package's hardhat.config.js => arb-shared-dependencies/index.js => dotenv.config({path})
3. Again, from the package's hardhat.config.js => arb-shared-dependencies/index.js => arb-shared-dependencies/hardhat.config.js => dotenv.config()
4. Again, from the package's hardhat.config.js => arb-shared-dependencies/index.js => dotenv.config({path})
5. From the script being executed => dotenv.config()