### PR TITLE
chore: use sdk for delayedL2 msg

### DIFF
--- a/packages/delayedInbox-l2msg/README.md
+++ b/packages/delayedInbox-l2msg/README.md
@@ -23,13 +23,13 @@ cp .env-sample .env
 Normal Transaction:
 
 ```bash
-yarn run normalTx
+yarn normalTx
 ```
 
 Withdraw Funds:
 
 ```bash
-yarn run withdrawFunds
+yarn withdrawFunds
 ```
 
 ## Curious to see the output on the Arbitrum chain?

--- a/packages/delayedInbox-l2msg/package.json
+++ b/packages/delayedInbox-l2msg/package.json
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "hardhat": "^2.10.1",
-    "@arbitrum/sdk": "^v3.0.0"
+    "@arbitrum/sdk": "^v3.1.2"
   }
 }

--- a/packages/delayedInbox-l2msg/scripts/normalTx.js
+++ b/packages/delayedInbox-l2msg/scripts/normalTx.js
@@ -11,13 +11,11 @@ requireEnvVariables(['DEVNET_PRIVKEY', 'L2RPC', 'L1RPC'])
  */
 const walletPrivateKey = process.env.DEVNET_PRIVKEY
 
-
 const l1Provider = new providers.JsonRpcProvider(process.env.L1RPC)
 const l2Provider = new providers.JsonRpcProvider(process.env.L2RPC)
 
 const l1Wallet = new Wallet(walletPrivateKey, l1Provider)
 const l2Wallet = new Wallet(walletPrivateKey, l2Provider)
-
 
 const main = async () => {
   await arbLog('DelayedInbox normal contract call (L2MSG_signedTx)')

--- a/packages/delayedInbox-l2msg/scripts/withdrawFunds.js
+++ b/packages/delayedInbox-l2msg/scripts/withdrawFunds.js
@@ -1,15 +1,13 @@
 const { providers, Wallet, ethers } = require('ethers')
 const { arbLog, requireEnvVariables } = require('arb-shared-dependencies')
 const { getL2Network } = require('@arbitrum/sdk/dist/lib/dataEntities/networks')
+const { InboxTools } = require('@arbitrum/sdk')
 const {
   NodeInterface__factory,
 } = require('@arbitrum/sdk/dist/lib/abi/factories/NodeInterface__factory')
 const {
   ArbSys__factory
 } = require('@arbitrum/sdk/dist/lib/abi/factories/ArbSys__factory')
-const {
-  IInbox__factory,
-} = require('@arbitrum/sdk/dist/lib/abi/factories/IInbox__factory')
 
 const {
   NODE_INTERFACE_ADDRESS,
@@ -22,7 +20,6 @@ requireEnvVariables(['DEVNET_PRIVKEY', 'L2RPC', 'L1RPC'])
  */
 const walletPrivateKey = process.env.DEVNET_PRIVKEY
 
-const L2MSG_signedTx = 4
 
 const l1Provider = new providers.JsonRpcProvider(process.env.L1RPC)
 const l2Provider = new providers.JsonRpcProvider(process.env.L2RPC)
@@ -30,32 +27,13 @@ const l2Provider = new providers.JsonRpcProvider(process.env.L2RPC)
 const l1Wallet = new Wallet(walletPrivateKey, l1Provider)
 const l2Wallet = new Wallet(walletPrivateKey, l2Provider)
 
-/**
- * We should use nodeInterface to get the gas estimate is because we
- * are making a delayed inbox message which doesn't need l1 calldata
- * gas fee part.
- */
-const estimateGasWithoutL1Part = async transactionl2Request => {
-  const nodeInterface = NodeInterface__factory.connect(
-    NODE_INTERFACE_ADDRESS,
-    l2Provider
-  )
-  const gasComponents = await nodeInterface.callStatic.gasEstimateComponents(
-    transactionl2Request.to,
-    false,
-    transactionl2Request.data,
-    {
-      from: transactionl2Request.from,
-      value: transactionl2Request.value
-    }
-  )
-  return gasComponents.gasEstimate.sub(gasComponents.gasEstimateForL1)
-}
 
 const main = async () => {
   await arbLog('DelayedInbox withdraw funds from l2 (L2MSG_signedTx)')
 
   const l2Network = await getL2Network(await l2Wallet.getChainId())
+
+  const inboxSdk = new InboxTools(l1Wallet, l2Network)
 
   /**
    * Here we have a arbsys abi to withdraw our funds; we'll be setting it by sending it as a message from delayed inbox!!!
@@ -71,73 +49,21 @@ const main = async () => {
     l1Wallet.address,
   ])
   
-
-  /**
-   * Encode the l2's signed tx so this tx can be executed on l2
-   */
-  const l2GasPrice = (await l2Provider.getGasPrice()).mul(11).div(10)
-
   const transactionl2Request = {
     data: calldatal2,
     to: ARB_SYS_ADDRESS,
-    nonce: await l2Wallet.getTransactionCount(),
-    value: 1, // 1 is needed because if we set 0 will affect the gas estimate
-    gasPrice: l2GasPrice,
-    chainId: l2Wallet.chainId,
-    from: l2Wallet.address,
-  }
-  let l2GasLimit
-
-  try {
-    l2GasLimit = (await estimateGasWithoutL1Part(transactionl2Request)).mul(2)
-  } catch (error) {
-    console.error(
-      "execution failed (estimate gas failed), try check your account's balance?"
-    )
+    value: 1, // Only set 1 wei since it just a test tutorial, you can set whatever you want in real runtime.
   }
 
-  transactionl2Request.gasLimit = l2GasLimit
-
-  const l2Balance = await l2Provider.getBalance(l2Wallet.address)
-
-  /**
-   * We need to check if the sender has enough funds on l2 to pay the gas fee, if have enough funds, the get the other part funds to withdraw.
-   */
-  if (l2Balance.lt(l2GasPrice.mul(l2GasLimit))) {
-    console.log(
-      'You l2 balance is not enough to pay the gas fee, please bridge some ethers to l2.'
-    )
-    return
-  } else {
-    transactionl2Request.value = l2Balance.sub(l2GasPrice.mul(l2GasLimit))
-  }
 
   /**
    * We need extract l2's tx hash first so we can check if this tx executed on l2 later.
    */
-  const l2SignedTx = await l2Wallet.signTransaction(transactionl2Request)
+  const l2SignedTx = await inboxSdk.signL2Tx(transactionl2Request, l2Wallet)
 
   const l2Txhash = ethers.utils.parseTransaction(l2SignedTx).hash
 
-  /**
-   * Pack the message data to parse to delayed inbox
-   */
-  const sendData = ethers.utils.solidityPack(
-    ['uint8', 'bytes'],
-    [ethers.utils.hexlify(L2MSG_signedTx), l2SignedTx]
-  )
-  console.log('Now we get the send data: ' + sendData)
-
-  /**
-   * Process the l1 delayed inbox tx, to process it, we need to have delayed inbox's abi and use it to encode the
-   * function call data. After that, we send this tx directly to delayed inbox.
-   */
-  const inbox = new ethers.Contract(
-    l2Network.ethBridge.inbox,
-    IInbox__factory.abi
-  )
-  const inboxInstance = inbox.connect(l1Wallet)
-  const resultsL1 = await inboxInstance.sendL2Message(sendData)
+  const resultsL1 = await inboxSdk.sendL2SignedTx(l2SignedTx)
 
   const inboxRec = await resultsL1.wait()
 
@@ -147,7 +73,7 @@ const main = async () => {
    * Now we successfully send the tx to l1 delayed inbox, then we need to wait the tx executed on l2
    */
   console.log(
-    `Now we need to wait tx: ${l2Txhash} to be included on l2 (may take 15 minutes, if longer than 30 minutes, you can use sdk to force include) ....... `
+    `Now we need to wait tx: ${l2Txhash} to be included on l2 (may take 15 minutes, if longer than 1 day, you can use sdk to force include) ....... `
   )
 
   const l2TxReceipt = await l2Provider.waitForTransaction(l2Txhash)

--- a/packages/delayedInbox-l2msg/scripts/withdrawFunds.js
+++ b/packages/delayedInbox-l2msg/scripts/withdrawFunds.js
@@ -3,15 +3,11 @@ const { arbLog, requireEnvVariables } = require('arb-shared-dependencies')
 const { getL2Network } = require('@arbitrum/sdk/dist/lib/dataEntities/networks')
 const { InboxTools } = require('@arbitrum/sdk')
 const {
-  NodeInterface__factory,
-} = require('@arbitrum/sdk/dist/lib/abi/factories/NodeInterface__factory')
-const {
-  ArbSys__factory
+  ArbSys__factory,
 } = require('@arbitrum/sdk/dist/lib/abi/factories/ArbSys__factory')
 
 const {
-  NODE_INTERFACE_ADDRESS,
-  ARB_SYS_ADDRESS
+  ARB_SYS_ADDRESS,
 } = require('@arbitrum/sdk/dist/lib/dataEntities/constants')
 requireEnvVariables(['DEVNET_PRIVKEY', 'L2RPC', 'L1RPC'])
 
@@ -20,13 +16,11 @@ requireEnvVariables(['DEVNET_PRIVKEY', 'L2RPC', 'L1RPC'])
  */
 const walletPrivateKey = process.env.DEVNET_PRIVKEY
 
-
 const l1Provider = new providers.JsonRpcProvider(process.env.L1RPC)
 const l2Provider = new providers.JsonRpcProvider(process.env.L2RPC)
 
 const l1Wallet = new Wallet(walletPrivateKey, l1Provider)
 const l2Wallet = new Wallet(walletPrivateKey, l2Provider)
-
 
 const main = async () => {
   await arbLog('DelayedInbox withdraw funds from l2 (L2MSG_signedTx)')
@@ -39,22 +33,18 @@ const main = async () => {
    * Here we have a arbsys abi to withdraw our funds; we'll be setting it by sending it as a message from delayed inbox!!!
    */
 
-  const arbSys = ArbSys__factory.connect(
-    ARB_SYS_ADDRESS,
-    l2Provider
-  )
-  
+  const arbSys = ArbSys__factory.connect(ARB_SYS_ADDRESS, l2Provider)
+
   const arbsysIface = arbSys.interface
   const calldatal2 = arbsysIface.encodeFunctionData('withdrawEth', [
     l1Wallet.address,
   ])
-  
+
   const transactionl2Request = {
     data: calldatal2,
     to: ARB_SYS_ADDRESS,
     value: 1, // Only set 1 wei since it just a test tutorial, you can set whatever you want in real runtime.
   }
-
 
   /**
    * We need extract l2's tx hash first so we can check if this tx executed on l2 later.


### PR DESCRIPTION
Since we support send signed l2 tx using `InboxTools` sdk in [v3.1.0](https://github.com/OffchainLabs/arbitrum-sdk/releases/tag/v3.1.0), so we should let this tutorial use sdk too.