### PR TITLE
Update bridging tutorials

### DIFF
--- a/packages/custom-token-bridging/contracts/L1Token.sol
+++ b/packages/custom-token-bridging/contracts/L1Token.sol
@@ -1,116 +1,84 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
 
-/*
- * Copyright 2020, Offchain Labs, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-pragma solidity ^0.6.11;
-
-import "./ICustomToken.sol";
+import "./interfaces/ICustomToken.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-interface IGatewayRouter {
-    function setGateway(
-        address _gateway,
-        uint256 _maxGas,
-        uint256 _gasPriceBid,
-        uint256 _maxSubmissionCost,
-        address creditBackAddress
-    ) external payable returns (uint256);
-}
-
-interface ICustomGateway {
+/**
+ * @title Interface needed to call function registerTokenToL2 of the L1CustomGateway
+ */
+interface IL1CustomGateway {
     function registerTokenToL2(
         address _l2Address,
         uint256 _maxGas,
         uint256 _gasPriceBid,
         uint256 _maxSubmissionCost,
-        address creditBackAddress
+        address _creditBackAddress
     ) external payable returns (uint256);
 }
 
-contract L1Token is ICustomToken, ERC20 {
-    address public bridge;
-    address public router;
+/**
+ * @title Interface needed to call function setGateway of the L2GatewayRouter
+ */
+interface IL1GatewayRouter {
+    function setGateway(
+        address _gateway,
+        uint256 _maxGas,
+        uint256 _gasPriceBid,
+        uint256 _maxSubmissionCost,
+        address _creditBackAddress
+    ) external payable returns (uint256);
+}
+
+contract L1Token is Ownable, ICustomToken, ERC20 {
+    address private customGatewayAddress;
+    address private routerAddress;
     bool private shouldRegisterGateway;
-    address public owner;
 
-    constructor(
-        address _bridge,
-        address _router,
-        uint256 _premine
-    ) public ERC20("L1CustomToken", "LCT") {
-        bridge = _bridge;
-        router = _router;
-        owner = msg.sender;
-        _mint(msg.sender, _premine);
-    }
-
-    // Modifier to check that the caller is the owner of the L1 Token Contract.
-    modifier onlyOwner() {
-        require(msg.sender == owner, "Not the owner of the L1 Token");
-        _;
-    }
-    function transferFrom(
-        address sender,
-        address recipient,
-        uint256 amount
-    ) public override(ERC20, ICustomToken) returns (bool) {
-        return ERC20.transferFrom(sender, recipient, amount);
-    }
-
-    function balanceOf(address account)
-        public
-        view
-        override(ERC20, ICustomToken)
-        returns (uint256)
-    {
-        return ERC20.balanceOf(account);
+    /**
+     * @dev See {ERC20-constructor} and {Ownable-constructor}
+     *
+     * An initial supply amount is passed, which is preminted to the deployer.
+     */
+    constructor(address _customGatewayAddress, address _routerAddress, uint256 _initialSupply) ERC20("L1CustomToken", "LCT") {
+        customGatewayAddress = _customGatewayAddress;
+        routerAddress = _routerAddress;
+        _mint(msg.sender, _initialSupply * 10 ** decimals());
     }
 
     /// @dev we only set shouldRegisterGateway to true when in `registerTokenOnL2`
     function isArbitrumEnabled() external view override returns (uint8) {
         require(shouldRegisterGateway, "NOT_EXPECTED_CALL");
-        return uint8(0xa4b1);
+        return uint8(0xb1);
     }
 
+    /// @dev See {ICustomToken-registerTokenOnL2}
     function registerTokenOnL2(
         address l2CustomTokenAddress,
-        uint256 maxSubmissionCostForCustomBridge,
+        uint256 maxSubmissionCostForCustomGateway,
         uint256 maxSubmissionCostForRouter,
-        uint256 maxGasForCustomBridge,
+        uint256 maxGasForCustomGateway,
         uint256 maxGasForRouter,
         uint256 gasPriceBid,
         uint256 valueForGateway,
         uint256 valueForRouter,
         address creditBackAddress
-    ) public payable override onlyOwner{
+    ) public override payable onlyOwner {
         // we temporarily set `shouldRegisterGateway` to true for the callback in registerTokenToL2 to succeed
         bool prev = shouldRegisterGateway;
         shouldRegisterGateway = true;
 
-        ICustomGateway(bridge).registerTokenToL2{ value: valueForGateway }(
+        IL1CustomGateway(customGatewayAddress).registerTokenToL2{ value: valueForGateway }(
             l2CustomTokenAddress,
-            maxGasForCustomBridge,
+            maxGasForCustomGateway,
             gasPriceBid,
-            maxSubmissionCostForCustomBridge,
+            maxSubmissionCostForCustomGateway,
             creditBackAddress
         );
 
-        IGatewayRouter(router).setGateway{ value: valueForRouter }(
-            bridge,
+        IL1GatewayRouter(routerAddress).setGateway{ value: valueForRouter }(
+            customGatewayAddress,
             maxGasForRouter,
             gasPriceBid,
             maxSubmissionCostForRouter,
@@ -120,9 +88,17 @@ contract L1Token is ICustomToken, ERC20 {
         shouldRegisterGateway = prev;
     }
 
-    function getChainId() public returns (uint256 chainId) {
-        assembly {
-            chainId := chainid()
-        }
+    /// @dev See {ERC20-transferFrom}
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public override(ICustomToken, ERC20) returns (bool) {
+        return super.transferFrom(sender, recipient, amount);
+    }
+
+    /// @dev See {ERC20-balanceOf}
+    function balanceOf(address account) public view override(ICustomToken, ERC20) returns (uint256) {
+        return super.balanceOf(account);
     }
 }

--- a/packages/custom-token-bridging/contracts/L2Token.sol
+++ b/packages/custom-token-bridging/contracts/L2Token.sol
@@ -1,71 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
 
-/*
- * Copyright 2020, Offchain Labs, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-pragma solidity ^0.6.11;
-
+import "./interfaces/IArbToken.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-
-interface IArbToken {
-    /**
-     * @notice should increase token supply by amount, and should (probably) only be callable by the L1 bridge.
-     */
-    function bridgeMint(address account, uint256 amount) external;
-
-    /**
-     * @notice should decrease token supply by amount, and should (probably) only be callable by the L1 bridge.
-     */
-    function bridgeBurn(address account, uint256 amount) external;
-
-    /**
-     * @return address of layer 1 token
-     */
-    function l1Address() external view returns (address);
-}
 
 contract L2Token is ERC20, IArbToken {
     address public l2Gateway;
     address public override l1Address;
-
-    constructor(address _l2Gateway, address _l1TokenAddress) public ERC20("L2CustomToken", "L2CT") {
-        l2Gateway = _l2Gateway;
-        l1Address = _l1TokenAddress;
-    }
-
-    function getChainId() public returns (uint256 chainId) {
-        assembly {
-            chainId := chainid()
-        }
-    }
 
     modifier onlyL2Gateway() {
         require(msg.sender == l2Gateway, "NOT_GATEWAY");
         _;
     }
 
+    constructor(address _l2Gateway, address _l1TokenAddress) ERC20("L2CustomToken", "LCT") {
+        l2Gateway = _l2Gateway;
+        l1Address = _l1TokenAddress;
+    }
+
     /**
-     * @notice should increase token supply by amount, and should (probably) only be callable by the L1 bridge.
+     * @notice should increase token supply by amount, and should only be callable by the L2Gateway.
      */
     function bridgeMint(address account, uint256 amount) external override onlyL2Gateway {
         _mint(account, amount);
     }
 
     /**
-     * @notice should decrease token supply by amount, and should (probably) only be callable by the L1 bridge.
+     * @notice should decrease token supply by amount, and should only be callable by the L2Gateway.
      */
     function bridgeBurn(address account, uint256 amount) external override onlyL2Gateway {
         _burn(account, amount);

--- a/packages/custom-token-bridging/contracts/interfaces/IArbToken.sol
+++ b/packages/custom-token-bridging/contracts/interfaces/IArbToken.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+
+/*
+ * Copyright 2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @title Minimum expected interface for L2 token that interacts with the L2 token bridge (this is the interface necessary
+ * for a custom token that interacts with the bridge, see TestArbCustomToken.sol for an example implementation).
+ */
+
+// solhint-disable-next-line compiler-version
+pragma solidity >=0.6.9 <0.9.0;
+
+interface IArbToken {
+    /**
+     * @notice should increase token supply by amount, and should (probably) only be callable by the L1 bridge.
+     */
+    function bridgeMint(address account, uint256 amount) external;
+
+    /**
+     * @notice should decrease token supply by amount, and should (probably) only be callable by the L1 bridge.
+     */
+    function bridgeBurn(address account, uint256 amount) external;
+
+    /**
+     * @return address of layer 1 token
+     */
+    function l1Address() external view returns (address);
+}

--- a/packages/custom-token-bridging/contracts/interfaces/ICustomToken.sol
+++ b/packages/custom-token-bridging/contracts/interfaces/ICustomToken.sol
@@ -16,19 +16,20 @@
  * limitations under the License.
  */
 
-pragma solidity ^0.6.11;
+// solhint-disable-next-line compiler-version
+pragma solidity >=0.6.9 <0.9.0;
 
 interface ArbitrumEnabledToken {
-    /// @notice should return `0xa4b1` if token is enabled for arbitrum gateways
+    /// @notice should return `0xb1` if token is enabled for arbitrum gateways
     function isArbitrumEnabled() external view returns (uint8);
 }
 
 /**
- * @title Minimum expected interface for L1 custom token (see TestCustomTokenL1.sol for an example implementation)
+ * @title Minimum expected interface for L1 custom token
  */
 interface ICustomToken is ArbitrumEnabledToken {
     /**
-     * @notice Should make an external call to EthERC20Bridge.registerCustomL2Token
+     * @notice Should make an external call to L1CustomGateway.registerTokenToL2 and L2GatewayRouter.setGateway
      */
     function registerTokenOnL2(
         address l2CustomTokenAddress,
@@ -49,4 +50,12 @@ interface ICustomToken is ArbitrumEnabledToken {
     ) external returns (bool);
 
     function balanceOf(address account) external view returns (uint256);
+}
+
+interface L1MintableToken is ICustomToken {
+    function bridgeMint(address account, uint256 amount) external;
+}
+
+interface L1ReverseToken is L1MintableToken {
+    function bridgeBurn(address account, uint256 amount) external;
 }

--- a/packages/custom-token-bridging/package.json
+++ b/packages/custom-token-bridging/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
-    "@openzeppelin/contracts": "^3.4.2",
+    "@openzeppelin/contracts": "^4.8.3",
     "chai": "^4.3.4",
     "ethers": "^5.1.2",
     "hardhat": "^2.6.6"

--- a/packages/custom-token-bridging/scripts/exec.js
+++ b/packages/custom-token-bridging/scripts/exec.js
@@ -82,7 +82,7 @@ const main = async () => {
   console.log('Registering custom token on L2:')
 
   /**
-   * ٍRegister custom token on our custom gateway
+   * Register custom token on our custom gateway
    */
   const registerTokenTx = await adminTokenBridger.registerCustomToken(
     l1CustomToken.address,
@@ -97,21 +97,26 @@ const main = async () => {
   )
 
   /**
-   * The L1 side is confirmed; now we listen and wait for the for the Sequencer to include the L2 side; we can do this by computing the expected txn hash of the L2 transaction.
-   * To compute this txn hash, we need our message's "sequence numbers", unique identifiers of each L1 to L2 message. We'll fetch them from the event logs with a helper method
+   * The L1 side is confirmed; now we listen and wait for the L2 side to be executed; we can do this by computing the expected txn hash of the L2 transaction.
+   * To compute this txn hash, we need our message's "sequence numbers", unique identifiers of each L1 to L2 message.
+   * We'll fetch them from the event logs with a helper method.
    */
   const l1ToL2Msgs = await registerTokenRec.getL1ToL2Messages(l2Provider)
 
   /**
    * In principle, a single L1 txn can trigger any number of L1-to-L2 messages (each with its own sequencer number).
-   * In this case, the registerTokenOnL2 method created 2 L1-to-L2 messages; (1) one to set the L1 token to the Custom Gateway via the Router, and (2) another to set the L1 token to its L2 token address via the Generic-Custom Gateway
+   * In this case, the registerTokenOnL2 method created 2 L1-to-L2 messages;
+   * - (1) one to set the L1 token to the Custom Gateway via the Router, and
+   * - (2) another to set the L1 token to its L2 token address via the Generic-Custom Gateway
    * Here, We check if both messages are redeemed on L2
    */
   expect(l1ToL2Msgs.length, 'Should be 2 messages.').to.eq(2)
+
   const setTokenTx = await l1ToL2Msgs[0].waitForStatus()
   expect(setTokenTx.status, 'Set token not redeemed.').to.eq(
     L1ToL2MessageStatus.REDEEMED
   )
+
   const setGateways = await l1ToL2Msgs[1].waitForStatus()
   expect(setGateways.status, 'Set gateways not redeemed.').to.eq(
     L1ToL2MessageStatus.REDEEMED

--- a/packages/token-deposit/contracts/DappToken.sol
+++ b/packages/token-deposit/contracts/DappToken.sol
@@ -1,71 +1,15 @@
-pragma solidity >=0.4.22;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
 
-contract DappToken {
-    string public name = "Dapp Token"; //Token name
-    string public symbol = "DAPP"; //Toekn symbol
-    string public standard = "Dapp Token v1.0";
-    uint256 public totalSupply;
-    uint8 public decimals = 2;
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-    mapping(address => uint256) public balanceOf; //stores the balance of addresses. Every time a token is baught/sold/transferred, this mapping is responsible for knowing who has each token
-    mapping(address => mapping(address => uint256)) public allowance;
-    //It keeps track of all of my appovals that I have approved for transferring tokens
-    //account A:  1)approved account B to spend 10 tokens
-    //            2)approved account C to spend 20 tokens
-    //            ...
-
-    event Transfer(address indexed _from, address indexed _to, uint256 _value);
-    event Approval(address indexed _owner, address indexed _spender, uint256 _value); //I (the owner) approved account spender to spend _value of my Dapp tokens o
-
-    //constructor: Set the value and the number of the tokens that we have
-    //everytime the smart contract is deployed
-    //The following cobstructor accepts the total supply as function arguments
-    constructor(uint256 _initialSupply) public {
-        balanceOf[msg.sender] = _initialSupply; //allocates the initial supply
-        totalSupply = _initialSupply; //the number of tokens that will exist and store it in a variable
-    }
-
-    //transfer function allows users to trasfer tokens and MUST fire the "transfer event"
-    //The function SHOULD throw exception if the _from address does not have enough tokens to spend
-    function transfer(address _to, uint256 _value) public returns (bool success) {
-        require(balanceOf[msg.sender] >= _value);
-        balanceOf[msg.sender] -= _value;
-        balanceOf[_to] += _value;
-        emit Transfer(msg.sender, _to, _value);
-        return true;
-    }
-
-    //approve function: allows sb to approve another account to spend tokens on tehir behalf. You're basically approving the exchange to spend x tokens on your behalf
-    //MUST trigger the approval event
-    function approve(address _spender, uint256 _value) public returns (bool success) {
-        //spender: the exchange
-
-        allowance[msg.sender][_spender] = _value; //set the allowance: the amount which _spender is still allowed to withdraw from _owner
-        //Allowance: If I approve the exchange to spend x Dapp tokens on my belhaf, that x gets stored in allowance
-
-        emit Approval(msg.sender, _spender, _value); //approve event
-        return true;
-    }
-
-    //Once you approve that transfer, the transferFrom function allows the exchange to do that
-    //acts like a transfer but on behalf on another account
-    //account A approved account B to spend _value
-    //so account B calls transferFrom function to transfer _value tokens from account A to some account (_to)
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _value
-    ) public returns (bool success) {
-        require(_value <= balanceOf[_from]);
-        require(_value <= allowance[_from][msg.sender]);
-
-        balanceOf[_from] -= _value; //update the balance of _from and _to
-        balanceOf[_to] += _value; //update the balance of _from and _to
-
-        allowance[_from][msg.sender] -= _value; //update the allowance; ammount of tokens the exchange (msg.sender) can spend on behalf of _from account
-
-        emit Transfer(_from, _to, _value); //transfer event: everytime there is a transfer happened we should emit an event
-
-        return true;
+contract DappToken is ERC20 {
+    /**
+     * @dev See {ERC20-constructor}.
+     *
+     * An initial supply amount is passed, which is pre-minted and sent to the deployer.
+     */
+    constructor(uint256 _initialSupply) ERC20("Dapp Token", "DAPP") {
+        _mint(msg.sender, _initialSupply * 10 ** decimals());
     }
 }

--- a/packages/token-deposit/package.json
+++ b/packages/token-deposit/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "@openzeppelin/contracts": "^4.8.3",
     "chai": "^4.3.4",
     "ethers": "^5.1.2",
     "hardhat": "^2.2.0"

--- a/packages/token-withdraw/contracts/DappToken.sol
+++ b/packages/token-withdraw/contracts/DappToken.sol
@@ -1,71 +1,15 @@
-pragma solidity >=0.4.22;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
 
-contract DappToken {
-    string public name = "Dapp Token"; //Token name
-    string public symbol = "DAPP"; //Toekn symbol
-    string public standard = "Dapp Token v1.0";
-    uint256 public totalSupply;
-    uint8 public decimals = 2;
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-    mapping(address => uint256) public balanceOf; //stores the balance of addresses. Every time a token is baught/sold/transferred, this mapping is responsible for knowing who has each token
-    mapping(address => mapping(address => uint256)) public allowance;
-    //It keeps track of all of my appovals that I have approved for transferring tokens
-    //account A:  1)approved account B to spend 10 tokens
-    //            2)approved account C to spend 20 tokens
-    //            ...
-
-    event Transfer(address indexed _from, address indexed _to, uint256 _value);
-    event Approval(address indexed _owner, address indexed _spender, uint256 _value); //I (the owner) approved account spender to spend _value of my Dapp tokens o
-
-    //constructor: Set the value and the number of the tokens that we have
-    //everytime the smart contract is deployed
-    //The following cobstructor accepts the total supply as function arguments
-    constructor(uint256 _initialSupply) public {
-        balanceOf[msg.sender] = _initialSupply; //allocates the initial supply
-        totalSupply = _initialSupply; //the number of tokens that will exist and store it in a variable
-    }
-
-    //transfer function allows users to trasfer tokens and MUST fire the "transfer event"
-    //The function SHOULD throw exception if the _from address does not have enough tokens to spend
-    function transfer(address _to, uint256 _value) public returns (bool success) {
-        require(balanceOf[msg.sender] >= _value);
-        balanceOf[msg.sender] -= _value;
-        balanceOf[_to] += _value;
-        emit Transfer(msg.sender, _to, _value);
-        return true;
-    }
-
-    //approve function: allows sb to approve another account to spend tokens on tehir behalf. You're basically approving the exchange to spend x tokens on your behalf
-    //MUST trigger the approval event
-    function approve(address _spender, uint256 _value) public returns (bool success) {
-        //spender: the exchange
-
-        allowance[msg.sender][_spender] = _value; //set the allowance: the amount which _spender is still allowed to withdraw from _owner
-        //Allowance: If I approve the exchange to spend x Dapp tokens on my belhaf, that x gets stored in allowance
-
-        emit Approval(msg.sender, _spender, _value); //approve event
-        return true;
-    }
-
-    //Once you approve that transfer, the transferFrom function allows the exchange to do that
-    //acts like a transfer but on behalf on another account
-    //account A approved account B to spend _value
-    //so account B calls transferFrom function to transfer _value tokens from account A to some account (_to)
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _value
-    ) public returns (bool success) {
-        require(_value <= balanceOf[_from]);
-        require(_value <= allowance[_from][msg.sender]);
-
-        balanceOf[_from] -= _value; //update the balance of _from and _to
-        balanceOf[_to] += _value; //update the balance of _from and _to
-
-        allowance[_from][msg.sender] -= _value; //update the allowance; ammount of tokens the exchange (msg.sender) can spend on behalf of _from account
-
-        emit Transfer(_from, _to, _value); //transfer event: everytime there is a transfer happened we should emit an event
-
-        return true;
+contract DappToken is ERC20 {
+    /**
+     * @dev See {ERC20-constructor}.
+     *
+     * An initial supply amount is passed, which is pre-minted and sent to the deployer.
+     */
+    constructor(uint256 _initialSupply) ERC20("Dapp Token", "DAPP") {
+        _mint(msg.sender, _initialSupply * 10 ** decimals());
     }
 }

--- a/packages/token-withdraw/package.json
+++ b/packages/token-withdraw/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "@openzeppelin/contracts": "^4.8.3",
     "chai": "^4.3.4",
     "ethers": "^5.1.2",
     "hardhat": "^2.2.0"

--- a/packages/token-withdraw/scripts/exec.js
+++ b/packages/token-withdraw/scripts/exec.js
@@ -25,8 +25,8 @@ const l2Wallet = new Wallet(walletPrivateKey, l2Provider)
 /**
  * Set the amount of token to be transferred to L2 and then withdrawn
  */
-const tokenDepositAmount = BigNumber.from(50)
-const tokenWithdrawAmount = BigNumber.from(20)
+const tokenAmount = BigNumber.from(50)
+const tokenAmountToWithdraw = BigNumber.from(20)
 
 const main = async () => {
   await arbLog('Withdraw token using Arbitrum SDK')
@@ -38,15 +38,8 @@ const main = async () => {
   addDefaultLocalNetwork()
 
   /**
-   * Use l2Network to create an Arbitrum SDK Erc20Bridger instance
-   * We'll use Erc20Bridger for its convenience methods around transferring token to L2 and back to L1
-   */
-  const l2Network = await getL2Network(l2Provider)
-  const erc20Bridge = new Erc20Bridger(l2Network)
-
-  /**
-   * Setup: we'll deploy a token contract, then approve and transfer onto L2 so we have some tokens to withdraw to L1
-   * (For play-by-play details on the deposit flow, see token_deposit repo)
+   * For the purpose of our tests, here we deploy an standard ERC20 token (DappToken) to L1
+   * It sends its deployer (us) the initial supply of 1000
    */
   console.log('Deploying the test DappToken to L1:')
   const L1DappToken = await (
@@ -55,31 +48,47 @@ const main = async () => {
   const l1DappToken = await L1DappToken.deploy(1000000000000000)
   await l1DappToken.deployed()
   console.log(`DappToken is deployed to L1 at ${l1DappToken.address}`)
-  console.log('Approving:')
+  const l1Erc20Address = l1DappToken.address
 
-  const erc20Address = l1DappToken.address
+  /**
+   * Use l2Network to create an Arbitrum SDK Erc20Bridger instance
+   * We'll use Erc20Bridger for its convenience methods around transferring token to L2 and back to L1
+   */
+  const l2Network = await getL2Network(l2Provider)
+  const erc20Bridger = new Erc20Bridger(l2Network)
+
+  /**
+   * Because the token might have decimals, we update the amounts to deposit and withdraw taking into account those decimals
+   */
+  const tokenDecimals = await l1DappToken.decimals()
+  const tokenDepositAmount = tokenAmount.mul(
+    BigNumber.from(10).pow(tokenDecimals)
+  )
+  const tokenWithdrawAmount = tokenAmountToWithdraw.mul(
+    BigNumber.from(10).pow(tokenDecimals)
+  )
 
   /**
    * The Standard Gateway contract will ultimately be making the token transfer call; thus, that's the contract we need to approve.
-   * erc20Bridge.approveToken handles this approval
+   * erc20Bridger.approveToken handles this approval
    * Arguments required are:
    * (1) l1Signer: The L1 address transferring token to L2
    * (2) erc20L1Address: L1 address of the ERC20 token to be deposited to L2
    */
-  const approveTx = await erc20Bridge.approveToken({
+  console.log('Approving:')
+  const approveTx = await erc20Bridger.approveToken({
     l1Signer: l1Wallet,
-    erc20L1Address: erc20Address,
+    erc20L1Address: l1Erc20Address,
   })
 
   const approveRec = await approveTx.wait()
   console.log(
     `You successfully allowed the Arbitrum Bridge to spend DappToken ${approveRec.transactionHash}`
   )
-  console.log('Transferring DappToken to L2:')
 
   /**
    * Deposit DappToken to L2 using Erc20Bridger. This will escrow funds in the Gateway contract on L1, and send a message to mint tokens on L2.
-   * The erc20Bridge.deposit method handles computing the necessary fees for automatic-execution of retryable tickets — maxSubmission cost & l2 gas price * gas — and will automatically forward the fees to L2 as callvalue
+   * The erc20Bridger.deposit method handles computing the necessary fees for automatic-execution of retryable tickets — maxSubmission cost & l2 gas price * gas — and will automatically forward the fees to L2 as callvalue
    * Also note that since this is the first DappToken deposit onto L2, a standard Arb ERC20 contract will automatically be deployed.
    * Arguments required are:
    * (1) amount: The amount of tokens to be transferred to L2
@@ -87,9 +96,10 @@ const main = async () => {
    * (2) l1Signer: The L1 address transferring token to L2
    * (3) l2Provider: An l2 provider
    */
-  const depositTx = await erc20Bridge.deposit({
+  console.log('Transferring DappToken to L2:')
+  const depositTx = await erc20Bridger.deposit({
     amount: tokenDepositAmount,
-    erc20L1Address: erc20Address,
+    erc20L1Address: l1Erc20Address,
     l1Signer: l1Wallet,
     l2Provider: l2Provider,
   })
@@ -114,8 +124,6 @@ const main = async () => {
         `L2 message failed: status ${L1ToL2MessageStatus[l2Result.status]}`
       )
 
-  console.log('Withdrawing:')
-
   /**
    * ... Okay, Now we begin withdrawing DappToken from L2. To withdraw, we'll use Erc20Bridger helper method withdraw
    * withdraw will call our L2 Gateway Router to initiate a withdrawal via the Standard ERC20 gateway
@@ -125,25 +133,24 @@ const main = async () => {
    * (2) erc20L1Address: L1 address of the ERC20 token
    * (3) l2Signer: The L2 address transferring token to L1
    */
-
-  const withdrawTx = await erc20Bridge.withdraw({
+  console.log('Withdrawing:')
+  const withdrawTx = await erc20Bridger.withdraw({
     amount: tokenWithdrawAmount,
     destinationAddress: l2Wallet.address,
-    erc20l1Address: erc20Address,
+    erc20l1Address: l1Erc20Address,
     l2Signer: l2Wallet,
   })
-
   const withdrawRec = await withdrawTx.wait()
   console.log(`Token withdrawal initiated! 🥳 ${withdrawRec.transactionHash}`)
+
   /**
    * And with that, our withdrawal is initiated! No additional time-sensitive actions are required.
-   * Any time after the transaction's assertion is confirmed, funds can be transferred out of the bridge via the outbox contract
+   * Any time after the transaction's assertion is confirmed (around 7 days), funds can be transferred out of the bridge via the outbox contract
    * We'll check our l2Wallet DappToken balance here:
    */
-
-  const l2Token = erc20Bridge.getL2TokenContract(
+  const l2Token = erc20Bridger.getL2TokenContract(
     l2Provider,
-    await erc20Bridge.getL2ERC20Address(erc20Address, l1Provider)
+    await erc20Bridger.getL2ERC20Address(l1Erc20Address, l1Provider)
   )
 
   const l2WalletBalance = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,16 +21,6 @@
     "@ethersproject/bytes" "^5.0.8"
     ethers "^5.1.0"
 
-"@arbitrum/sdk@^v3.1.0":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.1.1.tgz#f1cd96351dcae138ec8a6359926c1b1a81989463"
-  integrity sha512-nM97/qPIqJCa6xisZEiyWNKzhgBjlTeHeURu/yDF2r8OXfTV9oqfFlE3BtkcTZYzZXOlJsngMcISwRMXIKXbvQ==
-  dependencies:
-    "@ethersproject/address" "^5.0.8"
-    "@ethersproject/bignumber" "^5.1.1"
-    "@ethersproject/bytes" "^5.0.8"
-    ethers "^5.1.0"
-
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -897,7 +887,7 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.2.tgz#90d9e47bacfd8693bfad0ac8a394645575528d05"
   integrity sha512-xgWZYaPlrEOQo3cBj97Ufiuv79SPd8Brh4GcFYhPgb6WvAq4ppz8dWKL6h+jLAK01rUqMRp/TS9AdXgAeNvCLA==
 
-"@openzeppelin/contracts@3.4.2", "@openzeppelin/contracts@^3.4.2":
+"@openzeppelin/contracts@3.4.2":
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.2.tgz#d81f786fda2871d1eb8a8c5a73e455753ba53527"
   integrity sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==
@@ -906,6 +896,11 @@
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
   integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
+
+"@openzeppelin/contracts@^4.8.3":
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.3.tgz#cbef3146bfc570849405f59cba18235da95a252a"
+  integrity sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
This PR updates the following tutorials:

- token-deposit
- token-withdraw
- custom-token-bridging

It updates the solidity code, leveraging OpenZeppelin implementations and makes a few adjustments to the exec JS scripts (mostly naming and reordering to fit the new [How to pages](https://github.com/OffchainLabs/arbitrum-docs/pull/300))