### PR TITLE
Bump SDK dependency version

### DIFF
--- a/packages/address-table/package.json
+++ b/packages/address-table/package.json
@@ -14,6 +14,6 @@
     "hardhat": "^2.5.0"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2"
+    "@arbitrum/sdk": "^v3.1.9"
   }
 }

--- a/packages/custom-gateway-bridging/package.json
+++ b/packages/custom-gateway-bridging/package.json
@@ -13,7 +13,7 @@
     "hardhat": "^2.6.6"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2",
+    "@arbitrum/sdk": "^v3.1.9",
     "dotenv": "^8.2.0"
   }
 }

--- a/packages/custom-token-bridging/package.json
+++ b/packages/custom-token-bridging/package.json
@@ -13,7 +13,7 @@
     "hardhat": "^2.6.6"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2",
+    "@arbitrum/sdk": "^v3.1.9",
     "dotenv": "^8.2.0"
   }
 }

--- a/packages/delayedInbox-l2msg/package.json
+++ b/packages/delayedInbox-l2msg/package.json
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "hardhat": "^2.10.1",
-    "@arbitrum/sdk": "^v3.1.2"
+    "@arbitrum/sdk": "^v3.1.9"
   }
 }

--- a/packages/eth-deposit-to-different-address/package.json
+++ b/packages/eth-deposit-to-different-address/package.json
@@ -12,7 +12,7 @@
     "hardhat": "^2.2.0"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2",
+    "@arbitrum/sdk": "^v3.1.9",
     "dotenv": "^8.2.0"
   }
 }

--- a/packages/eth-deposit/package.json
+++ b/packages/eth-deposit/package.json
@@ -12,7 +12,7 @@
     "hardhat": "^2.2.0"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2",
+    "@arbitrum/sdk": "^v3.1.9",
     "dotenv": "^8.2.0"
   }
 }

--- a/packages/eth-withdraw/package.json
+++ b/packages/eth-withdraw/package.json
@@ -12,7 +12,7 @@
     "hardhat": "^2.2.0"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2",
+    "@arbitrum/sdk": "^v3.1.9",
     "dotenv": "^8.2.0"
   }
 }

--- a/packages/gas-estimation/package.json
+++ b/packages/gas-estimation/package.json
@@ -6,7 +6,7 @@
     "exec": "ts-node scripts/exec.ts"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2",
+    "@arbitrum/sdk": "^v3.1.9",
     "ts-node": "^10.8.1",
     "typescript": "^4.7.3"
   },

--- a/packages/greeter/package.json
+++ b/packages/greeter/package.json
@@ -12,7 +12,7 @@
     "hardhat": "^2.2.0"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2",
+    "@arbitrum/sdk": "^v3.1.9",
     "@arbitrum/nitro-contracts": "v1.0.2",
     "dotenv": "^8.2.0"
   }

--- a/packages/l1-confirmation-checker/package.json
+++ b/packages/l1-confirmation-checker/package.json
@@ -9,7 +9,7 @@
     "findSubmissionTx": "yarn ts-node scripts/exec.ts --action findSubmissionTx"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2",
+    "@arbitrum/sdk": "^v3.1.9",
     "@types/yargs": "^17.0.17",
     "ts-node": "^10.8.1",
     "typescript": "^4.7.3",

--- a/packages/outbox-execute/package.json
+++ b/packages/outbox-execute/package.json
@@ -13,7 +13,7 @@
     "hardhat": "^2.9.1"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2",
+    "@arbitrum/sdk": "^v3.1.9",
     "dotenv": "^8.2.0"
   }
 }

--- a/packages/redeem-failed-retryable/package.json
+++ b/packages/redeem-failed-retryable/package.json
@@ -13,7 +13,7 @@
     "hardhat": "^2.2.0"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2",
+    "@arbitrum/sdk": "^v3.1.9",
     "@arbitrum/nitro-contracts": "v1.0.2",
     "dotenv": "^8.2.0"
   }

--- a/packages/token-deposit/package.json
+++ b/packages/token-deposit/package.json
@@ -14,7 +14,7 @@
     "hardhat": "^2.2.0"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2",
+    "@arbitrum/sdk": "^v3.1.9",
     "dotenv": "^8.2.0"
   }
 }

--- a/packages/token-withdraw/package.json
+++ b/packages/token-withdraw/package.json
@@ -14,7 +14,7 @@
     "hardhat": "^2.2.0"
   },
   "dependencies": {
-    "@arbitrum/sdk": "^v3.1.2",
+    "@arbitrum/sdk": "^v3.1.9",
     "dotenv": "^8.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,10 @@
   optionalDependencies:
     sol2uml "2.2.0"
 
-"@arbitrum/sdk@^v3.1.2":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.1.4.tgz#2088e09be4feaaf1ba3701290416e26f0407765e"
-  integrity sha512-G0hWl+rST4/vLIXJrNbw03q1YNwyzrhmLCfEckNOcLxCZzzqUv2iLkwabP3bKbfzFKP71ObepTDIREtmfEGjbA==
+"@arbitrum/sdk@^v3.1.9":
+  version "3.1.11"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.1.11.tgz#14fa67daceef7568b949e4a2695d561dd47eec5b"
+  integrity sha512-qD+igbOn8IoBH6ofvoV8OVYiEv/Dhszw9mFNp1QDY6srBihGAh/cUuA1PQ+tBSdhYda+gWcELBT5kbbVkpbE9w==
   dependencies:
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"


### PR DESCRIPTION
This PR bumps the SDK version of all packages so tutorials can be run on Arbitrum Sepolia or any Orbit chains settling to it.