### PR TITLE
Fixed the gas estimation tutorial not working on arbitrum goerli

### DIFF
--- a/packages/gas-estimation/scripts/exec.ts
+++ b/packages/gas-estimation/scripts/exec.ts
@@ -97,7 +97,14 @@ const gasEstimator = async () => {
     // NOTE: This one might be a bit confusing, but l1GasEstimated (B in the formula) is calculated based on l2 gas fees
     const l1Cost = l1GasEstimated.mul(l2EstimatedPrice);
     // NOTE: This is similar to 140 + utils.hexDataLength(txData);
-    const l1Size = l1Cost.div(l1EstimatedPrice);
+    
+    let l1Size;
+    if(l1EstimatedPrice.eq(0)) {
+        // If the L1 price is 0, we set the size to 0
+        l1Size = 0;
+    }else{
+        l1Size = l1Cost.div(l1EstimatedPrice).add(140);
+    }
 
     // Getting the result of the formula
     // ---------------------------------


### PR DESCRIPTION
This pull request addresses a gas estimation issue on the Arbitrum Goerli testnet. The core problem stemmed from the fact that Arbitrum Goerli does not settle its transactions on Layer 1 (L1), leading to a division by zero error in gas estimation.

Changes
- Added a check to see if the amount of L1 gas cost to send the tx is zero, if so it avoid a division by zero error. The code now accurately estimates gas on the mainnet and arbitrum testnets