### PR TITLE
Correct Documentation Language and Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ yarn run testAll
 - 🌉 [Bridging a custom token through a custom gateway](./packages/custom-gateway-bridging/)
 - ✈️ [Send a signed transaction from the parent chain](./packages/delayedInbox-l2msg/)
 - 🎁 [Redeem pending retryable ticket](./packages/redeem-pending-retryable/)
-- 🧮 [Gas Estimation](./packages/gas-estimation/)
+- 🧮 [Gas estimation](./packages/gas-estimation/)
 - 🌀 [Deposit Ether or Tokens from L1 to L3](./packages/l1-l3-teleport/)
 
 ## How to run the tutorials against a custom network


### PR DESCRIPTION
### 1. Replace "betweens" with "between"
Reason: The word "betweens" is not typically used in English. The correct form is "between", which is used to describe the position or relationship between two entities or locations.

### 2. Replace "From root directory" with "From the root directory"
Change: Adding the article "the" to "From root directory" to make it grammatically correct.
Reason: In English, when referring to a specific place or object, the article "the" is often required before the noun. In this case, "root directory" refers to a specific location in a file system, so "the" should be added.

### 3. Replace "Gas estimation" with "Gas Estimation"

Reason: In technical documentation, certain terms like "Gas Estimation" may be capitalized to indicate that it is a specific feature, concept, or heading.

### 4. Ethers.js Typo
The sentence has a small issue with the use of "Ethers-js." The correct name of the library is "Ethers.js" (with a dot instead of a hyphen).

### 5. Fill Information Phrase
The sentence has a small mistake in the phrase "fill the information of your chain." A more natural and grammatically correct phrase would be:

"fill in the information of your chain" 