### PR TITLE
Add support for custom gas token chains

### DIFF
--- a/packages/gas-estimation/scripts/exec.ts
+++ b/packages/gas-estimation/scripts/exec.ts
@@ -1,7 +1,11 @@
 import { utils, providers } from 'ethers';
 import { NodeInterface__factory } from '@arbitrum/sdk/dist/lib/abi/factories/NodeInterface__factory';
 import { NODE_INTERFACE_ADDRESS } from '@arbitrum/sdk/dist/lib/dataEntities/constants';
-const { requireEnvVariables, addCustomNetworkFromFile } = require('arb-shared-dependencies');
+const {
+  requireEnvVariables,
+  addCustomNetworkFromFile,
+  arbLog,
+} = require('arb-shared-dependencies');
 
 // Importing configuration //
 require('dotenv').config();
@@ -24,6 +28,8 @@ const destinationAddress = '0x1234563d5de0d7198451f87bcbf15aefd00d434d';
 const txData = '0x';
 
 const gasEstimator = async () => {
+  await arbLog('Gas estimation');
+
   // ***************************
   // * Gas formula explanation *
   // ***************************
@@ -93,7 +99,9 @@ const gasEstimator = async () => {
   // -------------------------------------------------------------------------------
   // NOTE: This one might be a bit confusing, but parentChainGasEstimated (B in the formula) is calculated based on child-chain's gas fees
   const parentChainCost = parentChainGasEstimated.mul(childChainEstimatedPrice);
-  const parentChainSize = parentChainCost.div(parentChainEstimatedPrice);
+  const parentChainSize = parentChainEstimatedPrice.eq(0)
+    ? 0
+    : parentChainCost.div(parentChainEstimatedPrice);
 
   // Getting the result of the formula
   // ---------------------------------

--- a/packages/redeem-pending-retryable/scripts/exec-createFailedRetryable.js
+++ b/packages/redeem-pending-retryable/scripts/exec-createFailedRetryable.js
@@ -15,6 +15,7 @@ const {
   getArbitrumNetwork,
 } = require('@arbitrum/sdk');
 const { getBaseFee } = require('@arbitrum/sdk/dist/lib/utils/lib');
+const { ERC20__factory } = require('@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory');
 require('dotenv').config();
 requireEnvVariables(['PRIVATE_KEY', 'CHAIN_RPC', 'PARENT_CHAIN_RPC']);
 
@@ -164,13 +165,38 @@ const main = async () => {
     `Sending greeting to the child chain with ${parentToChildMessageGasParams.deposit.toString()} callValue for child chain's fees:`,
   );
   const maxGasLimit = 10;
+
+  /**
+   * We now find out whether the child chain we are using is a custom gas token chain
+   * We need to perform an additional approve call to transfer
+   * the native tokens to pay for the gas of the retryable tickets.
+   */
+  const isCustomGasTokenChain =
+    childChainNetwork.nativeToken && childChainNetwork.nativeToken !== ethers.constants.AddressZero;
+
+  if (isCustomGasTokenChain) {
+    // Approve the gas token to be sent to the contract
+    console.log('Giving allowance to the greeter to transfer the chain native token');
+    const nativeToken = new ethers.Contract(
+      childChainNetwork.nativeToken,
+      ERC20__factory.abi,
+      parentChainWallet,
+    );
+    const approvalTransaction = await nativeToken.approve(
+      greeterParent.address,
+      ethers.utils.parseEther('1'),
+    );
+    const approvalTransactionReceipt = await approvalTransaction.wait();
+    console.log(`Approval transaction receipt is: ${approvalTransactionReceipt.transactionHash}`);
+  }
+
   const setGreetingTransaction = await greeterParent.setGreetingInChild(
     newGreeting, // string memory _greeting,
     parentToChildMessageGasParams.maxSubmissionCost,
     maxGasLimit,
     gasPriceBid,
     {
-      value: parentToChildMessageGasParams.deposit,
+      value: isCustomGasTokenChain ? 0 : parentToChildMessageGasParams.deposit,
     },
   );
   const setGreetingTransactionReceipt = await setGreetingTransaction.wait();


### PR DESCRIPTION
This PR adds support for custom gas token chains in the following tutorials:
- gas-estimation (it was trying to divide by 0 in one of the steps)
- redeem-pending-retryable